### PR TITLE
Correct errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13) # tested working 3.13.0, 3.13.4, 3.14.5
+cmake_minimum_required(VERSION 3.18.2) 
 cmake_policy(SET CMP0076 NEW) # Ensure target_sources converts relative paths
 
 project(brille)
@@ -78,22 +78,12 @@ endif (BRILLE_PROFILING)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Use CMake v3.12+ FindPython3 to find the system-compatible interpreter *and* libraries at once
-# This solves a potential issue on convoluted Windows build systems which have multiple
-# python interpreters, some of which do not have build-system compatibility (I'm looking at you, msys2 python)
-# In such a case FindPythonInterp might point to the wrong python interpreter and then further configuration
-# steps will fail to find any (or any compatible) libraries which match the interpreter.
-find_package(Python3 COMPONENTS Interpreter Development)
-# Since FindPython3 and FindPythonInterp set different variables, fake the FindPythonInterp result
-# to prevent it running if called by, e.g., FindPybind11
-if(Python3_FOUND AND NOT PYTHON_EXECUTABLE)
-  set(PYTHONINTERP_FOUND ON)
-  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-  set(PYTHON_VERSION_STRING "${Python3_VERSION}")
-  set(PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
-  set(PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
-  set(PYTHON_VERSION_PATCH ${Python3_VERSION_PATCH})
+if (PYTHON_EXECUTABLE)
+  # Ensure the provided Python interpreter is used
+  set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
 endif()
+# With modern CMake, this find_package forces pybind11 to use FindPython instead of its custom tools
+find_package(Python3 COMPONENTS Interpreter Development)
 
 # Attempt to find catch2 to handle C++ testing
 if(BRILLE_BUILD_TESTING)
@@ -149,7 +139,7 @@ if(NOT pybind11_FOUND)
 endif()
 
 # Read the version of brille
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from version_info import version_number; version_number()"
+execute_process(COMMAND ${Python3_EXECUTABLE} -c "from version_info import version_number; version_number()"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE BRILLE_VERSION)
 # So that we can print it to the console along with the specified build type
@@ -159,13 +149,13 @@ message(STATUS "Build brille v${BRILLE_VERSION} with type ${CMAKE_BUILD_TYPE}")
 # This file will be updated even if no other source files are modified but it does not
 # cause relinking the module (if it is the *only* file which changes)
 add_custom_target(write_version_info
-  COMMAND ${PYTHON_EXECUTABLE} version_info.py src/version.hpp
+  COMMAND ${Python3_EXECUTABLE} version_info.py src/version.hpp
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 
 # Create a single header by contatenating all headers in src/
 add_custom_target(single_header
-  COMMAND ${PYTHON_EXECUTABLE} acme.py ${BRILLE_SINGLE_HEADER} -o ${CMAKE_BINARY_DIR}
+  COMMAND ${Python3_EXECUTABLE} acme.py ${BRILLE_SINGLE_HEADER} -o ${CMAKE_BINARY_DIR}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   DEPENDS write_version_info
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 #   )
 # endif()
 
-message(STATUS "Using interpreter: ${PYTHON_EXECUTABLE}")
+message(STATUS "Using interpreter: ${Python3_EXECUTABLE}")
 
 
 set(CXX_SOURCES

--- a/src/array.hpp
+++ b/src/array.hpp
@@ -351,6 +351,7 @@ private:
     // std::reduce can perform the same operation in parallel, but isn't implemented
     // in the gcc libraries until v9.3. Since the number of dimensions is (probably)
     // small a serial algorithm is not a giant speed hit.
+    if (s.begin() == s.end()) return ind_t(0); // an empty shape has no size
     size_t sz = std::accumulate(s.begin(), s.end(), ind_t(1), std::multiplies<ind_t>());
     return static_cast<ind_t>(sz);
   }

--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -344,7 +344,7 @@ private:
       std::string msg = "The shift { " + std::to_string(_shift) + " ";
       msg += "} and size { ";
       for (auto x: _shape) msg += std::to_string(x) + " ";
-      msg += "} of an Array must not exceed the allocated pointer size ";
+      msg += "} of an Array2 must not exceed the allocated pointer size ";
       msg += std::to_string(_num);
       throw std::runtime_error(msg);
     }

--- a/src/interpolator.hpp
+++ b/src/interpolator.hpp
@@ -506,7 +506,7 @@ public:
   runtime.
   */
   size_t bytes_per_point() const {
-    size_t n_elements = data_.numel()/data_.size(0);
+    size_t n_elements = data_.numel() > 0u ? data_.numel()/data_.size(0) : 0u;
     return n_elements * sizeof(T);
   }
 private:

--- a/src/permutation.hpp
+++ b/src/permutation.hpp
@@ -352,7 +352,8 @@ brille::ind_t nind = static_cast<brille::ind_t>(neighbour_idx);
 brille::ind_t cind = static_cast<brille::ind_t>(centre_idx);
 for (brille::ind_t i=0; i<Nobj; ++i)
   for (brille::ind_t j=0; j<Nobj; ++j)
-    if (permutations.val(nind, i) == rowsol[j]) permutations.val(cind, i) = static_cast<size_t>(j);
+    if (permutations.val(nind, i) == static_cast<size_t>(rowsol[j]))
+      permutations.val(cind, i) = static_cast<size_t>(j);
 
 delete[] cost;
 delete[] usol;
@@ -541,7 +542,8 @@ brille::ind_t nind = static_cast<brille::ind_t>(neighbour_idx);
 brille::ind_t cind = static_cast<brille::ind_t>(centre_idx);
 for (brille::ind_t i=0; i<Nobj; ++i)
   for (brille::ind_t j=0; j<Nobj; ++j)
-    if (permutations.val(nind, i) == rowsol[j]) permutations.val(cind, i) = static_cast<size_t>(j);
+    if (permutations.val(nind, i) == static_cast<size_t>(rowsol[j]))
+      permutations.val(cind, i) = static_cast<size_t>(j);
 
 delete[] cost;
 delete[] usol;

--- a/wrap/CMakeLists.txt
+++ b/wrap/CMakeLists.txt
@@ -25,7 +25,7 @@ target_sources(${BRILLE_PYTHON_MODULE} PRIVATE ${BRILLE_PYTHON_MODULE_SOURCES})
 if(BRILLE_BUILD_TESTING)
   #ensure that the python interpreter knows how to import numpy
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import numpy"
+    COMMAND ${Python3_EXECUTABLE} -c "import numpy"
     RESULT_VARIABLE EXIT_CODE
     OUTPUT_QUIET
   )
@@ -34,9 +34,9 @@ if(BRILLE_BUILD_TESTING)
     set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}/tests")
     file(GLOB python_tests_ tests/test_*.py)
     foreach(python_test ${python_tests_})
-      add_test(NAME ${python_test} COMMAND ${PYTHON_EXECUTABLE} ${python_test} )
+      add_test(NAME ${python_test} COMMAND ${Python3_EXECUTABLE} ${python_test} )
     endforeach()
   else()
-    message(WARNING "Install working numpy for ${PYTHON_EXECUTABLE} to run all tests")
+    message(WARNING "Install working numpy for ${Python3_EXECUTABLE} to run all tests")
   endif()
 endif()


### PR DESCRIPTION
[Fix] Divide by zero and unallocated Array errors
- When a grid-like object has not-yet been filled it has no information
  per grid-point, so `bytes_per_point` should be 0 but, due to a mistake,
  the C++ method attempted to calculate 0/0, which resulted in a
  division-by-zero exception.
- The division now only happens if the number of allocated Array
  elements is larger than zero. Otherwise the method returns 0.

- The grid methods `values` and `vectors` in the same case would return
  empty arrays. Due to a bug, these empty Arrays could not be created
  since the allocated storage size (0) was smaller than the
  erroneous-calculated-size (1, should be 0).
- The method calculating an Array size from its shape now returns 0 if
  the shape is empty instead of 1. This allows the empty Array to have 0
  expected size and 0 allocated size, which is fine.

[Fix] CMake & pybind11 in a Conda environment config errors

- The convoluted solution to avoid mixing Python interpreter and library
  versions that I implemented previously failed in the case of a Conda
  environment build system. The specification of `PYTHON_EXECUTABLE` by
  the setuptools build was ignored by pybind11 and find_package(Python
  ...) did not find the active Conda python.
- Moving to a newer minimum CMake of 3.15 enables the parameter
  `Python3_FIND_VIRTUALENV` with default value `FIRST`. This allows
  find_package to default to the active Conda python. Due to how my
  workaround was written, a user could not override the python by
  specifying `PYTHON_EXECUTABLE`, so a further change was necessary.
  This change was a further increase in minimu CMake to 3.18.2, removal
  of my workaround (no longer necessary, see pybind11 FAQ), and allowing
  the pre-definition of `Python3_EXECUTABLE` to force find_package to
  find the 'right' python.
- Since my workaround was removed and find_package only defines
  `Python3_EXECUTABLE`, future CMakeLists.txt modifications should avoid
  using the `PYTHON_EXECUTABLE` variable, as it will not be set in all
  cases.