### PR TITLE
[Fix] implementation bugs

### DIFF
--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -447,8 +447,38 @@ public:
   ind_t count(cmp expr, T val) const;
   Array2<bool> is(cmp expr, T val) const;
   std::vector<ind_t> find(cmp expr, T val) const;
+  /*!\brief Determine the per-element truth-value of this Array2 compared with provided data
+
+  \param expr The comparison to be performed
+  \param that The values to compare against
+
+  \return The truth value of the provided comparison between the stored and
+          provided data, will be the same shape a this Array2.
+
+  \note The shape of the compared-against Array2 must match or be broadcastable
+        to the shape of this Array2.
+  */
   template<class R> Array2<bool> is(cmp expr, const Array2<R>& that) const;
-  template<class R> std::vector<bool> is(cmp expr, const std::vector<R>& val) const;
+  /*!\brief Determine the per-row truth-value of this Array2 compared with provided data
+
+  \param expr The comparison to be performed
+  \param row The values to compare against, with length equal to the size of the
+             second dimension of this Array2.
+
+  \return The per-row truth value of the provided comparison between the stored
+          and provided data.
+  */
+  template<class R> std::vector<bool> row_is(cmp expr, const std::vector<R>& row) const;
+  /*!\brief Determine the element truth-value of this Array2 compared with provided data
+
+  \param expr The comparison to be performed
+  \param vals The values to compare against, with length equal to the number of
+              elements in this Array2
+
+  \return The per-element truth value of the provided comparison between the
+          stored and provided data.
+  */
+  template<class R> std::vector<bool> each_is(cmp expr, const std::vector<R>& vals) const;
   template<class R> bool is(const Array2<R>& that) const;
   std::vector<bool> is_unique() const;
   std::vector<ind_t> unique_idx() const;

--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -114,6 +114,9 @@ public:
     // if a dimension is 1 (or 0?) then its stride does not impact here
     return (_shape[0]<2||expected[0]==_stride[0]) && (_shape[1]<2||expected[1]==_stride[1]);
   }
+  bool is_vector() const {
+    return (_shape[0] == 1u || _shape[1] == 1u);
+  }
   // empty initializer
   explicit Array2()
   : _data(nullptr), _num(0), _shift(0u), _own(false), _ref(std::make_shared<char>()),

--- a/src/array2.tpp
+++ b/src/array2.tpp
@@ -746,29 +746,29 @@ Array2<T>::is(const brille::cmp expr, const Array2<R>& that) const {
 template<class T>
 template<class R>
 std::vector<bool>
-Array2<T>::is(const brille::cmp expr, const std::vector<R>& val) const{
-  auto no = this->numel();
-  // assert(val.size() == _shape[1]);
-  // std::vector<bool> out;
-  // out.reserve(_shape[0]);
-  // brille::Comparer<T,R> op(expr);
-  // for (ind_t i=0; i<_shape[0]; ++i)
-  //   out.push_back(op(_shape[1], this->ptr(i), _stride[1], val.data(), 1u));
-  // return out;
-
-  assert(val.size() == _shape[1] || val.size() == no);
+Array2<T>::row_is(const brille::cmp expr, const std::vector<R>& row) const{
+  assert(row.size() == _shape[1]);
   std::vector<bool> out;
   brille::Comparer<T,R> op(expr);
-  if (val.size() == _shape[1]){
-    out.reserve(_shape[0]);
-    for (ind_t i=0; i<_shape[0]; ++i)
-      out.push_back(op(_shape[1], this->ptr(i), _stride[1], val.data(), 1u));
-  } else {
-    out.reserve(no);
-    for (ind_t i=0; i<no; ++i)
-      out.push_back(op(this->val(i), val[i]));
-  }
+  out.reserve(_shape[0]);
+  // loop over rows, comparing each row to the input values (a std::vector has stride of 1)
+  for (ind_t i=0; i<_shape[0]; ++i)
+    out.push_back(op(_shape[1], this->ptr(i), _stride[1], row.data(), 1u));
+  return out;
+}
 
+template<class T>
+template<class R>
+std::vector<bool>
+Array2<T>::each_is(const brille::cmp expr, const std::vector<R>& vals) const{
+  auto no = this->numel();
+  assert(vals.size() == no);
+  std::vector<bool> out;
+  brille::Comparer<T,R> op(expr);
+  out.reserve(no);
+  // loop over whole array in linear-index order
+  for (ind_t i=0; i<no; ++i)
+    out.push_back(op(this->val(i), vals[i]));
   return out;
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -52,3 +52,6 @@ using namespace brille;
     return w.ws_row > 0 ? w.ws_row : std::numeric_limits<int>::max();
   }
 #endif
+
+// Create the global DebugPrinter
+DebugPrinter brille::printer("");

--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -381,7 +381,8 @@ private:
 };
 
 //! The single namespace wide `DebugPrinter` used with the logging macros.
-static DebugPrinter printer("");
+// static DebugPrinter printer("");
+extern DebugPrinter printer;
 
 /*! \brief A simple timer for use in debugging and profiling
 

--- a/src/triangulation_layers.hpp
+++ b/src/triangulation_layers.hpp
@@ -395,7 +395,7 @@ private:
   TetMap connect(const size_t high, const size_t low) const{
     omp_set_num_threads(omp_get_max_threads());
     Stopwatch<> stopwatch;
-    stopwatch.tic();
+    if (brille::printer.datetime()) stopwatch.tic(); // we only need to start the timer if we are printing timing information
     TetMap map(layers[high].number_of_tetrahedra());
     long long mapsize = brille::utils::u2s<long long, size_t>(map.size());
 #if defined(__GNUC__) && !defined(__llvm__) && __GNUC__ < 9
@@ -433,8 +433,8 @@ private:
         if (add || layers[low].get_tetrahedron(j).intersects(tethi)) map[i].push_back(j);
       }
     }
-    stopwatch.toc();
-    info_update("Connect ",layers[high].number_of_tetrahedra()," to ",layers[low].number_of_tetrahedra()," completed in ",stopwatch.elapsed()," ms");
+    if (brille::printer.datetime()) stopwatch.toc();
+    info_update_if(brille::printer.datetime(), "Connect ",layers[high].number_of_tetrahedra()," to ",layers[low].number_of_tetrahedra()," completed in ",stopwatch.elapsed()," ms");
     // we now have a TetMap which contains, for every tetrahedral index of the
     // higher level, all tetrahedral indices of the lower level which touch the
     // higher tetrahedron or share some part of its volume.

--- a/src/triangulation_layers.hpp
+++ b/src/triangulation_layers.hpp
@@ -416,7 +416,7 @@ private:
       for (double r: layers[low].get_circum_radii()) sumrad.push_back(layers[high].get_circum_radii()[i]+r);
       // if two circumsphere centers are closer than the sum of their radii
       // they are close enough to possibly overlap:
-      auto close_enough = norm(layers[low].get_circum_centres() - cchi).is(brille::cmp::le, sumrad);
+      auto close_enough = norm(layers[low].get_circum_centres() - cchi).each_is(brille::cmp::le, sumrad);
       for (ind_t j=0; j < close_enough.size(); ++j) if (close_enough[j])
       {
         bool add = false;


### PR DESCRIPTION
- Extracting Array2 elements should only require a vector-like list of
  elements not necessarily a (N,1) Array2.
  The DebugPrinter brille::printer was not singular, with multiple
  versions existing in the compiled code -- this prevented using the
  datetime() return value to control timing/printing information in
  triangulation_layers.hpp.
  The layer-connection timing information should not always be printed.
- Array2::extract now takes (1,N) or (N,1) arrays of indexes. Fixing
  this highlighed a problem with Array2::is, which has also been fixed.
  There is now a single global brille::printer, declared `extern` in
  debug.hpp and constructed in debug.cpp (instead of declared `static`
  and constructed in debug.hpp).
  The layer-connection timing information is only printed if
  brille::printer.datetime() is true (which is false by default)
- Changing the behaviour of Array2::extract and Array2::is might effect
  other parts of brille. Testing should identify this if it happens.

Merging this PR should close #54 