### PR TITLE
Fixes for trilcinic lattices

### DIFF
--- a/src/bz.cpp
+++ b/src/bz.cpp
@@ -521,13 +521,11 @@ brille::intersect_at(
   LQVec<double>& intersect, const int idx
 ){
   double detM = brille::normals_matrix_determinant(n_i,n_j,n_k);
-  if (std::abs(detM) > 1e-10){
-    auto tmp = cross(n_j,n_k)*dot(p_i,n_i) + cross(n_k,n_i)*dot(p_j,n_j) + cross(n_i,n_j)*dot(p_k,n_k);
-    tmp /= detM;
-    intersect.set(idx, tmp);
-    return true;
-  }
-  return false;
+  if (brille::approx::scalar(detM, 0.)) return false;
+  auto tmp = cross(n_j,n_k)*dot(p_i,n_i) + cross(n_k,n_i)*dot(p_j,n_j) + cross(n_i,n_j)*dot(p_k,n_k);
+  tmp /= detM;
+  intersect.set(idx, tmp);
+  return true;
 }
 
 bool
@@ -538,13 +536,11 @@ brille::intersect_at(
   LQVec<double>& intersect, const int idx
 ){
   double detM = brille::normals_matrix_determinant(n_i,n_j,n_k);
-  if (std::abs(detM) > 1e-10){
-    auto tmp = cross(n_j,n_k)*dot(p_i,n_i) + cross(n_k,n_i)*dot(p_j,n_j);
-    tmp /= detM;
-    intersect.set(idx, tmp);
-    return true;
-  }
-  return false;
+  if (brille::approx::scalar(detM, 0.)) return false;
+  auto tmp = cross(n_j,n_k)*dot(p_i,n_i) + cross(n_k,n_i)*dot(p_j,n_j);
+  tmp /= detM;
+  intersect.set(idx, tmp);
+  return true;
 }
 
 bool
@@ -555,13 +551,11 @@ brille::intersect_at(
   LQVec<double>& intersect, const int idx
 ){
   double detM = brille::normals_matrix_determinant(n_i,n_j,n_k);
-  if (std::abs(detM) > 1e-10){
-    auto tmp = cross(n_j,n_k)*dot(p_i,n_i);
-    tmp /= detM;
-    intersect.set(idx, tmp);
-    return true;
-  }
-  return false;
+  if (brille::approx::scalar(detM, 0.)) return false;
+  auto tmp = cross(n_j,n_k)*dot(p_i,n_i);
+  tmp /= detM;
+  intersect.set(idx, tmp);
+  return true;
 }
 
 bool
@@ -571,9 +565,8 @@ brille::intersect_at(
   const LQVec<double>& n_k,
   LQVec<double>& intersect, const int idx
 ){
-  if (std::abs(brille::normals_matrix_determinant(n_i,n_j,n_k)) > 1e-10){
-    intersect.set(idx, 0*intersect.view(idx));
-    return true;
-  }
-  return false;
+  double detM = brille::normals_matrix_determinant(n_i,n_j,n_k);
+  if (brille::approx::scalar(detM, 0.)) return false;
+  intersect.set(idx, 0*intersect.view(idx));
+  return true;
 }

--- a/src/lattice.hpp
+++ b/src/lattice.hpp
@@ -342,6 +342,10 @@ public:
   }
   //! Check whether the pointgroup has the space-inversion operator, ̄1.
   bool has_space_inversion() const { return ptgsym.has_space_inversion(); }
+  //! Check if the spacegroup is triclinic
+  bool is_triclinic() const {
+    return ptgsym.higher(1).size() == 0;
+  }
   Basis get_basis() const {return basis; }
   //template <class R, class II>
   Basis set_basis(const std::vector<std::array<double,3>>& pos, const std::vector<ind_t>& typ) {

--- a/src/pointgroup.cpp
+++ b/src/pointgroup.cpp
@@ -196,7 +196,7 @@ static void set_transformation_matrix(int *tmat, const int axes[3]);
 Pointgroup brille::ptg_get_transformation_matrix(int *transform_mat, const int *rotations, const int num_rotations)
 {
   int i, pg_num;
-  int axes[3];
+  int axes[3]{0,0,0};
   PointSymmetry pointsym;
   Pointgroup pointgroup;
   for (i=0; i<9; i++) transform_mat[i]=0;
@@ -205,7 +205,8 @@ Pointgroup brille::ptg_get_transformation_matrix(int *transform_mat, const int *
   pointgroup = Pointgroup(pg_num);
   if (pg_num > 0) {
     pointsym = brille::ptg_get_pointsymmetry(rotations, num_rotations);
-    get_axes(axes, pointgroup.laue, pointsym);
+    if (get_axes(axes, pointgroup.laue, pointsym) == 0)
+      throw std::runtime_error("Could not set pointgroup axes!");
     set_transformation_matrix(transform_mat, axes);
   }
   return pointgroup;
@@ -351,7 +352,7 @@ static int get_axes(int axes[3], const Laue laue, const PointSymmetry & pointsym
   case Laue::_6mmm: laue_one_axis(axes, pointsym, 3); break;
   case Laue::_m3  : lauennn(axes, pointsym, 2); break;
   case Laue::_m3m : lauennn(axes, pointsym, 4); break;
-	default: return 0;
+	default: axes[0] = axes[1] = axes[2] = 0; return 0;
   }
   return 1;
 }


### PR DESCRIPTION
[Add] Lattice is_triclinic method

[Refactor] intersect_at to use approx::scalar

[Refactor] wedge_brute_force and wedge_triclinic

- The `irreducible_vertex_search` algorithm seems to be susceptible to
  rounding errors, and was abandonded for non-triclinic spacegroups when
  `wedge_search` was deprecated in favor of `wedge_brute_force`. This is
  a problem because `wedge_triclinic` still uses it to define the
  irreducible Brillouin zone polyhedron.
  Additionally, wedge_triclinic only ever tried to use the [111] normal
  plane as an irreducible wedge normal which may not have produced nice
  results in all cases; and if that algorithm failed it would be called
  multiple times by `wedge_brute_force` due to the logic flow.
- Since `wedge_brute_force` might need to be called multiple times, but
  `wedge_triclinic` need not, the two methods have been separated with
  logic in the `BrillouinZone` constructor controlling which is called.
  Additionally, `wedge_triclinic` uses the first Brillouin zone normals
  preferentially as the single dividing plane normal before resorting to
  the Cartesian axes and finally [111]. Finally, `wedge_triclinic` has
  been switched to using `Polyhedron::bisect` which appears to be more
  robust to rounding error problems.
- There are now quite a few unused methods floating around inside of
  `BrillouinZone`. These should be removed as they have been proven to
  be less robust than alternative `Polyhedron` based alternatives.

This fixes #56 