### PR TITLE
CMake build system changes

### DIFF
--- a/.github/workflows/main_push_pull_request.yml
+++ b/.github/workflows/main_push_pull_request.yml
@@ -38,9 +38,11 @@ jobs:
           extra-specs: python=${{ matrix.python-version }}
       - run: echo "pythonInterpreter=`which python`" >> $GITHUB_ENV
       - if: startsWith(matrix.variant.os, 'macos')
-        run: brew install tree; tree /Users/runner/.conan
+        run: brew install tree; tree /Users/runner/.conan || echo "No conan directory"
       - name: configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.cmake-type }} -D PYTHON3_EXECUTABLE=${{ env.pythonInterpreter }}
+      - if: startsWith(matrix.variant.os, 'macos')
+        run: tree /Users/runner/.conan || echo "No conan directory"
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v1.1.0
         id: cpu-cores

--- a/.github/workflows/main_push_pull_request.yml
+++ b/.github/workflows/main_push_pull_request.yml
@@ -38,7 +38,7 @@ jobs:
           extra-specs: python=${{ matrix.python-version }}
       - run: echo "pythonInterpreter=`which python`" >> $GITHUB_ENV
       - if: startsWith(matrix.variant.os, 'macos')
-        run: brew install tree & tree /Users/runner/.conan
+        run: brew install tree; tree /Users/runner/.conan
       - name: configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.cmake-type }} -D PYTHON3_EXECUTABLE=${{ env.pythonInterpreter }}
       - name: Get number of CPU cores

--- a/.github/workflows/main_push_pull_request.yml
+++ b/.github/workflows/main_push_pull_request.yml
@@ -37,6 +37,8 @@ jobs:
           cache-env: true
           extra-specs: python=${{ matrix.python-version }}
       - run: echo "pythonInterpreter=`which python`" >> $GITHUB_ENV
+      - if: startsWith(matrix.variant.os, 'macos')
+        run: brew install tree & tree /Users/runner/.conan
       - name: configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.cmake-type }} -D PYTHON3_EXECUTABLE=${{ env.pythonInterpreter }}
       - name: Get number of CPU cores

--- a/.github/workflows/main_push_pull_request.yml
+++ b/.github/workflows/main_push_pull_request.yml
@@ -36,10 +36,6 @@ jobs:
           environment-file: .github/config/${{ matrix.variant.cmake-preset }}.yml
           cache-env: true
           extra-specs: python=${{ matrix.python-version }}
-      - name: CCache
-        uses: hendrikmuhs/ccache-action@v1.2.8
-        with:
-          key: ${{ matrix.variant.os }}
       - run: echo "pythonInterpreter=`which python`" >> $GITHUB_ENV
       - name: configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.cmake-type }} -D PYTHON3_EXECUTABLE=${{ env.pythonInterpreter }}

--- a/.github/workflows/package_deploy.yml
+++ b/.github/workflows/package_deploy.yml
@@ -131,7 +131,7 @@ jobs:
       working-directory: wheelhouse
     - run: echo "${{ steps.wheel.outputs.wheel }}"
     - name: Sphinx Docker build
-      uses: g5t/sphinxer@v2.1.0
+      uses: g5t/sphinxer@v2.3.0
       with:
         source_dir: repository
         pages_dir: io

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(FETCH_CATCH2_REPO https://github.com/catchorg/Catch2)
 option(BRILLE_HDF5 "Add HDF5 file-based IO" ON)
 option(REQUIRE_SYSTEM_HIGHFIVE "Never attempt to fetch HighFive" OFF)
 mark_as_advanced(REQUIRE_SYSTEM_HIGHFIVE)
-set(MINIMUM_HIGHFIVE_VERSION 2.4.1)
+set(MINIMUM_HIGHFIVE_VERSION 2.6.2)
 SET(FETCH_HIGHFIVE_REPO https://github.com/BlueBrain/HighFive)
 
 # find_program(CMAKE_CXX_CPPCHECK NAMES cppcheck)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ set(FETCH_CATCH2_REPO https://github.com/catchorg/Catch2)
 # Optional support of HDF5-based IO
 option(BRILLE_HDF5 "Add HDF5 file-based IO" ON)
 option(REQUIRE_SYSTEM_HIGHFIVE "Never attempt to fetch HighFive" OFF)
+if (BRILLE_HDF5)
+    # Include the HDF5 IO methods -- safe since configuring will fail if HDF5/HighFive is not available
+    add_definitions(-DUSE_HIGHFIVE)
+endif()
 mark_as_advanced(REQUIRE_SYSTEM_HIGHFIVE)
 set(MINIMUM_HIGHFIVE_VERSION 2.6.2)
 SET(FETCH_HIGHFIVE_REPO https://github.com/BlueBrain/HighFive)
@@ -118,20 +122,6 @@ else()
 endif()
 # Attempt to find pybind11 to handle CPython bindings
 git_fetch(pybind11 ${MINIMUM_PYBIND11_VERSION} ${FETCH_PYBIND11_REPO} ${REQUIRE_SYSTEM_PYBIND11})
-
-# HighFive is used to simplify the interface with HDF5:
-# Override some default settings
-if (BRILLE_HDF5)
-  set(HIGHFIVE_USE_BOOST OFF)
-  set(HIGHFIVE_UNIT_TESTS OFF)
-  set(HIGHFIVE_EXAMPLES OFF)
-  set(HIGHFIVE_BUILD_DOCS OFF)
-  git_fetch(highfive ${MINIMUM_HIGHFIVE_VERSION} ${FETCH_HIGHFIVE_REPO} ${REQUIRE_SYSTEM_HIGHFIVE})
-  if (highfive_FOUND)
-    # message(STATUS "Adding HighFive precompiler macro flag")
-    add_definitions(-DUSE_HIGHFIVE)
-  endif()
-endif(BRILLE_HDF5)
 
 # Read the version of brille
 include(checkgit)

--- a/cmake/brille-conan.cmake
+++ b/cmake/brille-conan.cmake
@@ -17,12 +17,16 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_BINARY_DIR})
 if (DEFINED ENV{CONAN_USER_HOME})
     message(STATUS "Use $ENV{CONAN_USER_HOME} as CONAN_USER_HOME")
 endif()
-#conan_cmake_configure(REQUIRES hdf5/1.12.0 ${CONAN_LLVM_OPENMP} GENERATORS cmake_find_package OPTIONS hdf5:shared=False hdf5:hl=False hdf5:with_zlib=False)
 conan_cmake_configure(
-        REQUIRES hdf5/1.12.0
+        REQUIRES
+        hdf5/1.12.0
         ${CONAN_LLVM_OPENMP}
-        GENERATORS cmake_find_package
-        OPTIONS hdf5:shared=False hdf5:hl=False hdf5:with_zlib=False
+        GENERATORS
+        cmake_find_package
+        OPTIONS
+        hdf5:shared=False
+        hdf5:hl=False
+        hdf5:with_zlib=False
 )
 conan_cmake_autodetect(conan_settings)
 conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_CURRENT_BINARY_DIR} BUILD outdated REMOTE conancenter SETTINGS ${conan_settings})

--- a/cmake/brille-conan.cmake
+++ b/cmake/brille-conan.cmake
@@ -17,6 +17,12 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_BINARY_DIR})
 if (DEFINED ENV{CONAN_USER_HOME})
     message(STATUS "Use $ENV{CONAN_USER_HOME} as CONAN_USER_HOME")
 endif()
-conan_cmake_configure(REQUIRES hdf5/1.12.0 ${CONAN_LLVM_OPENMP} GENERATORS cmake_find_package OPTIONS hdf5:shared=False hdf5:hl=False hdf5:with_zlib=False)
+#conan_cmake_configure(REQUIRES hdf5/1.12.0 ${CONAN_LLVM_OPENMP} GENERATORS cmake_find_package OPTIONS hdf5:shared=False hdf5:hl=False hdf5:with_zlib=False)
+conan_cmake_configure(
+        REQUIRES hdf5/1.14.0
+        ${CONAN_LLVM_OPENMP}
+        GENERATORS cmake_find_package
+        OPTIONS hdf5:shared=False hdf5:hl=False hdf5:with_zlib=False
+)
 conan_cmake_autodetect(conan_settings)
 conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_CURRENT_BINARY_DIR} BUILD outdated REMOTE conancenter SETTINGS ${conan_settings})

--- a/cmake/brille-conan.cmake
+++ b/cmake/brille-conan.cmake
@@ -19,7 +19,7 @@ if (DEFINED ENV{CONAN_USER_HOME})
 endif()
 #conan_cmake_configure(REQUIRES hdf5/1.12.0 ${CONAN_LLVM_OPENMP} GENERATORS cmake_find_package OPTIONS hdf5:shared=False hdf5:hl=False hdf5:with_zlib=False)
 conan_cmake_configure(
-        REQUIRES hdf5/1.14.0
+        REQUIRES hdf5/1.12.0
         ${CONAN_LLVM_OPENMP}
         GENERATORS cmake_find_package
         OPTIONS hdf5:shared=False hdf5:hl=False hdf5:with_zlib=False

--- a/cmake/brille-hdf5.cmake
+++ b/cmake/brille-hdf5.cmake
@@ -1,4 +1,11 @@
-if(BRILLE_HDF5 AND highfive_FOUND)
+# HighFive is used to simplify the interface with HDF5:
+# Override some default settings
+if (BRILLE_HDF5)
+    set(HIGHFIVE_USE_BOOST OFF)
+    set(HIGHFIVE_UNIT_TESTS OFF)
+    set(HIGHFIVE_EXAMPLES OFF)
+    set(HIGHFIVE_BUILD_DOCS OFF)
+    git_fetch(highfive ${MINIMUM_HIGHFIVE_VERSION} ${FETCH_HIGHFIVE_REPO} ${REQUIRE_SYSTEM_HIGHFIVE})
     foreach(HF_TARGET IN LISTS CXX_TARGETS)
         # message(STATUS "Adding HighFive library to ${HF_TARGET}")
         target_link_libraries(${HF_TARGET} PUBLIC HighFive)

--- a/cmake/checkgit.cmake
+++ b/cmake/checkgit.cmake
@@ -54,40 +54,37 @@ function(checkGitRead git_hash)
 endfunction()
 
 function(checkGitVersion git_version safe_version)
-
   execute_process(
     COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    WORKING_DIRECTORY ${pre_configure_dir}
     OUTPUT_VARIABLE GIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    WORKING_DIRECTORY ${pre_configure_dir}
     OUTPUT_VARIABLE GIT_BRANCH
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "from datetime import datetime; print(datetime.now().isoformat(timespec='minutes'))"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     OUTPUT_VARIABLE GIT_CONFIGURE_TIME
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "import setuptools_scm as s; print(s.get_version())"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    WORKING_DIRECTORY ${pre_configure_dir}
     OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "import setuptools_scm as s; print('.'.join(s.get_version().split('.')[:3]))"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    WORKING_DIRECTORY ${pre_configure_dir}
     OUTPUT_VARIABLE GIT_SAFE_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "import platform; print(platform.node())"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     OUTPUT_VARIABLE GIT_HOSTNAME
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )

--- a/lib/hdf5/LICENSE
+++ b/lib/hdf5/LICENSE
@@ -1,0 +1,88 @@
+Copyright Notice and License Terms for
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+-----------------------------------------------------------------------------
+
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 2006 by The HDF Group.
+
+NCSA HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 1998-2006 by The Board of Trustees of the University of Illinois.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted for any
+purpose (including commercial purposes) provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions, and
+   the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions,
+   and the following disclaimer in the documentation and/or materials provided with the distribution.
+3. Neither the name of The HDF Group, the name of the University, nor the name of any Contributor
+   may be used to endorse or promote products derived from this software without specific prior
+   written permission from The HDF Group, the University, or the Contributor, respectively.
+
+DISCLAIMER:
+THIS SOFTWARE IS PROVIDED BY THE HDF GROUP AND THE CONTRIBUTORS "AS IS" WITH NO
+WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED. IN NO EVENT SHALL THE HDF GROUP OR
+THE CONTRIBUTORS BE LIABLE FOR ANY DAMAGES SUFFERED BY THE USERS ARISING OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+You are under no obligation whatsoever to provide any bug fixes, patches, or upgrades to the features,
+functionality or performance of the source code ("Enhancements") to anyone; however, if you choose
+to make your Enhancements available either publicly, or directly to The HDF Group, without imposing a
+separate written license agreement for such Enhancements, then you hereby grant the following
+license: a non-exclusive, royalty-free perpetual license to install, use, modify, prepare derivative works,
+incorporate into other computer software, distribute, and sublicense such enhancements or derivative
+works thereof, in binary and source code form.
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Limited portions of HDF5 were developed by Lawrence Berkeley National Laboratory (LBNL). LBNL's
+Copyright Notice and Licensing Terms can be found here: COPYING_LBNL_HDF5 file in this directory or
+at http://support.hdfgroup.org/ftp/HDF5/releases/COPYING_LBNL_HDF5.
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Contributors: National Center for Supercomputing Applications (NCSA) at the University of Illinois,
+Fortner Software, Unidata Program Center (netCDF), The Independent JPEG Group (JPEG), Jean-loup
+Gailly and Mark Adler (gzip), and Digital Equipment Corporation (DEC).
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the Lawrence Berkeley National Laboratory (LBNL)
+and the United States Department of Energy under Prime Contract No. DE-AC02-05CH11231.
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from Lawrence Livermore National Laboratory and the
+United States Department of Energy under Prime Contract No. DE-AC52-07NA27344.
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the University of California, Lawrence Livermore
+National Laboratory (UC LLNL). The following statement applies to those portions of the product and
+must be retained in any redistribution of source code, binaries, documentation, and/or accompanying
+materials:
+
+This work was partially produced at the University of California, Lawrence Livermore National
+Laboratory (UC LLNL) under contract no. W-7405-ENG-48 (Contract 48) between the U.S. Department
+of Energy (DOE) and The Regents of the University of California (University) for the operation of UC
+LLNL.
+
+DISCLAIMER:
+THIS WORK WAS PREPARED AS AN ACCOUNT OF WORK SPONSORED BY AN AGENCY OF THEUNITED
+STATES GOVERNMENT. NEITHER THE UNITED STATES GOVERNMENT NOR THE UNIVERSITY OF
+CALIFORNIA NOR ANY OF THEIR EMPLOYEES, MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY OR RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF
+ANY INFORMATION, APPARATUS, PRODUCT, OR PROCESS DISCLOSED, OR REPRESENTS THAT ITS USE
+WOULD NOT INFRINGE PRIVATELY- OWNED RIGHTS. REFERENCE HEREIN TO ANY SPECIFIC
+COMMERCIAL PRODUCTS, PROCESS, OR SERVICE BY TRADE NAME, TRADEMARK, MANUFACTURER, OR
+OTHERWISE, DOES NOT NECESSARILY CONSTITUTE OR IMPLY ITS ENDORSEMENT, RECOMMENDATION,
+OR FAVORING BY THE UNITED STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA. THE VIEWS
+AND OPINIONS OF AUTHORS EXPRESSED HEREIN DO NOT NECESSARILY STATE OR REFLECT THOSE OF
+THE UNITED STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA, AND SHALL NOT BE USED FOR
+ADVERTISING OR PRODUCT ENDORSEMENT PURPOSES.
+
+-----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,8 @@ list(APPEND CXX_SOURCES
   symmetry.cpp
   vertex_map_set.cpp
 )
-if(BRILLE_HDF5 AND highfive_FOUND)
+
+if(BRILLE_HDF5)
     list(APPEND CXX_SOURCES hdf_interface.cpp)
 endif()
 

--- a/src/bz.hpp
+++ b/src/bz.hpp
@@ -792,10 +792,10 @@ public:
     ok &= _first.to_hdf(group, "first");
     ok &= _irreducible.to_hdf(group, "irreducible");
     ok &= ir_wedge_normals.to_hdf(group, "ir_wedge_normals");
-    group.createAttribute("time_reversal", time_reversal);
-    group.createAttribute("has_inversion", has_inversion);
-    group.createAttribute("is_primitive", is_primitive);
-    group.createAttribute("no_ir_mirroring", no_ir_mirroring);
+    group.createAttribute("time_reversal", time_reversal ? 1 : 0);
+    group.createAttribute("has_inversion", has_inversion ? 1 : 0);
+    group.createAttribute("is_primitive", is_primitive ? 1 : 0);
+    group.createAttribute("no_ir_mirroring", no_ir_mirroring ? 1 : 0);
     group.createAttribute("approx_tolerance", approx_tolerance);
     group.createAttribute("float_tolerance", float_tolerance);
     return ok;
@@ -811,8 +811,7 @@ public:
     auto poly = BrillouinZone::poly_t::from_hdf(group, "first");
     auto ir_p = BrillouinZone::poly_t::from_hdf(group, "irreducible");
     auto ir_w = bArray<double>::from_hdf(group, "ir_wedge_normals");
-    bool tr, hi, ip, nim;
-    int tol;
+    int tr, hi, ip, nim, tol;
     double f_tol;
     group.getAttribute("time_reversal").read(tr);
     group.getAttribute("has_inversion").read(hi);
@@ -820,7 +819,7 @@ public:
     group.getAttribute("no_ir_mirroring").read(nim);
     group.getAttribute("approx_tolerance").read(tol);
     group.getAttribute("float_tolerance").read(f_tol);
-    return {lat, olat, poly, ir_p, ir_w, tr, hi, ip, nim, tol, f_tol};
+    return {lat, olat, poly, ir_p, ir_w, tr > 0, hi > 0, ip > 0, nim > 0, tol, f_tol};
   }
   [[nodiscard]] bool
   to_hdf(const std::string &filename, const std::string &entry,

--- a/wrap/_brille.cpp
+++ b/wrap/_brille.cpp
@@ -43,6 +43,7 @@ void wrap_version(pybind11::module & m){
   m.attr("__version__") = version_number;
   m.attr("version") = meta_version;
   m.attr("git_revision") = git_revision;
+  m.attr("git_branch") = git_branch;
   m.attr("build_datetime") = build_datetime;
   m.attr("build_hostname") = build_hostname;
 }


### PR DESCRIPTION
As indicated in #90, the CMake build and test action failed after the most recent push into the master branch.
The build can fail when attempting to build missing dependent library code via Conan.
Testing has been undertaken in an attempt to identify the cause of the problem, but an obvious answer has not been found.
The best guess explanation is that occasionally the conan recipie fails to download a valid project for some unknown reason.
If this explanation is correct, the hope that when this happens simply re-running the failed workflow(s) will solve the problem.
This solution has not been tested in practice.

## Additional changes
- [`HighFive`](https://www.github.com/BlueBrain/HighFive) updated from `v2.4.1` to `v2.6.2`;
which no longer allows bool attribute values in HDF5 files, it is unclear if this was previously undefined behaviour or a bug.
- Changes to the `checkgit.cmake` module to always run `git` and `setuptools_scm` from the project root.
Previously the working folder was the CMake source directory (set by `-S`) on configuration,
but the `--build` directory at build time.
- A copy of the HDF5 license is now included within the source at `lib/hdf5/LICENSE`.
It should be added to the documentation or within any binary for any distributed binaries compiled with parts of the library.
- The compiled `_brille` Python module will now expose *which* repository branch it was built from.
This will help identify development builds where the version number, number of developement commits, and partial commit hash may still be confusing.

## Non-changes
- `HighFive` is licensed under the `Boost` license which only requires reproduction of the license for redistribution of the source code.
- Newer versions of HDF5, `v1.12.1`, `v1.12.2`, and `v1.14.0`, exist on `conancenter` but these could not be used due a missing include of `librt` on ubuntu-22.04 with gcc 12.
- Installing, configuring, and using conan before the main `CMake` configuration might be a solution to the problem; but introduced new build complications with the need for platform specific configurations.
