### PR TITLE
[Add] Numpy hard dependency, cleanup pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,6 @@ requires =[
   "setuptools_scm[toml]>='6.2'",
   "wheel",
   "cmake>=3.18.2",
-#  "numpy==1.13.3; python_version<'3.5'",
-#  "oldest-supported-numpy; python_version>='3.5'",
   "conan==1.57.0",
 ]
 
@@ -18,19 +16,11 @@ test-command = "python -m unittest discover -s {package}/wrap/tests"
 before-test = "pip install numpy"
 build-verbosity = 1
 
-#[tool.cibuildwheel.linux]
-#before-all = "yum install -y hdf5-devel"
-
-#[tool.cibuildwheel.macos]
-#before-all = "brew install hdf5"
-
 [tools.cibuildwheel.windows]
-#before-all = "mamba install hdf5"
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair -w {dest_dir} -v {wheel}"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-#before-all = "apk add hdf5-dev"
 before-test = "echo 'Override building numpy since no wheels are provided'"
 test-command = "echo 'Override test command under musl libc until we can install a numpy wheel'"

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
     long_description_content_type="text/markdown",
     ext_modules=[CMakeExtension('brille._brille')],
     packages=find_packages(str(PACKAGE_ROOT)),
+    install_requires=['numpy'],
     extras_require={'plotting': ['matplotlib>=2.2.0', ], 'vis': ['pyglet>=1.5.27', 'vispy>=0.12.1', ]},
     cmdclass=dict(build_ext=CMakeBuild),
     url="https://github.com/brille/brille",


### PR DESCRIPTION
Updating the whole build system to make more use of the pyproject.toml file instead of setup.py may be worthwhile, but it is left for a future development.