### PR TITLE
[Ref] restore musllinux cp3.9+ wheel tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ skip = ["cp36-*", "cp37-*", "pp*"]  # all skipped for speed, except on Windows w
 
 [[tool.cibuildwheel.overrides]]
 select = "cp38-musllinux*"
+test-requires = []
 before-test = "echo 'Override building numpy since no wheels are provided'"
 test-command = "echo 'Override test command under musl libc until we can install a numpy wheel'"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ skip = ["cp36-*", "cp37-*", "pp*"]  # all skipped for speed, except on Windows w
 # repair-wheel-command = "delvewheel repair -w {dest_dir} -v {wheel}"
 
 [[tool.cibuildwheel.overrides]]
-select = "*-musllinux*"
+select = "cp38-musllinux*"
 before-test = "echo 'Override building numpy since no wheels are provided'"
 test-command = "echo 'Override test command under musl libc until we can install a numpy wheel'"
 
@@ -95,7 +95,6 @@ extend-exclude = [
 extend-select = [
   "UP",  # pyupgrade
 ]
-
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test-requires = ["numpy", "pytest"]
 test-command = "pytest {package}/wrap/tests"
 build-verbosity = 1
 skip = ["cp36-*", "cp37-*", "pp*"]  # all skipped for speed, except on Windows where PyPy builds don't work(?)
+test-skip = "cp38-musllinux*"
 
 # GitHub Actions + cibuildwheel + delvewheel leads to memory access errors that are not present
 # for cibuildwheel with or without delvewheel (but without GitHub Actions).
@@ -77,13 +78,6 @@ skip = ["cp36-*", "cp37-*", "pp*"]  # all skipped for speed, except on Windows w
 # [tool.cibuildwheel.windows]
 # before-build = "pip install delvewheel"
 # repair-wheel-command = "delvewheel repair -w {dest_dir} -v {wheel}"
-
-[[tool.cibuildwheel.overrides]]
-select = "cp38-musllinux*"
-test-requires = []
-before-test = "echo 'Override building numpy since no wheels are provided'"
-test-command = "echo 'Override test command under musl libc until we can install a numpy wheel'"
-
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
There are no musllinux numpy wheels on PyPI for Python 3.8 or earlier, and building numpy from source is time consuming; so cibuildwheel was instructed to skip testing installed musllinux wheels.

This change should allow the Python 3.9+ wheels to be tested on all platforms, skipping only tests for `cp38-musllinux*` wheels.