### PR TITLE
Mac runner

### DIFF
--- a/.github/workflows/main_push_pull_request.yml
+++ b/.github/workflows/main_push_pull_request.yml
@@ -26,10 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - { os: ubuntu-22.04} # current Ubuntu latest
+          - { os: ubuntu-22.04} # previous Ubuntu
           - { os: macos-13}     # last Intel macOS
-          - { os: macos-14}     # current macOS latest, arm64
-          - { os: windows-2022} # current Windows latest
+          - { os: macos-14}     # Previous macOS latest, arm64
+          - { os: macos-15}     # current macOS latest, arm64
+          - { os: macos-15-intel } # new intel mac (amd64) test platform
+          - { os: windows-2022} # previous Windows
         python-version: ["3.10"]
         cmake-type: ['Release']
 

--- a/src/subscript.hpp
+++ b/src/subscript.hpp
@@ -135,7 +135,7 @@ public:
   : _shape(o._shape), _inpt(o._inpt), _sub(o._sub), _fixed(o._fixed), _first(o._first)
   {}
   explicit SubIt(const SubIt<T>* o)
-  : _shape(o->_shape), _inpt(o->_inpt), _sub(o->_sub), _fixed(o->_fixed), _first(o->first)
+  : _shape(o->_shape), _inpt(o->_inpt), _sub(o->_sub), _fixed(o->_fixed), _first(o->_first)
   {}
 
   SubIt& operator=(const SubIt<T>& o){
@@ -248,7 +248,7 @@ public:
   : _shape(o._shape), _inpt(o._inpt), _sub(o._sub), _fixed(o._fixed), _first(o._first)
   {}
   explicit SubIt2(const SubIt2<T>* o)
-  : _shape(o->_shape), _inpt(o->_inpt), _sub(o->_sub), _fixed(o->_fixed), _first(o->first)
+  : _shape(o->_shape), _inpt(o->_inpt), _sub(o->_sub), _fixed(o->_fixed), _first(o->_first)
   {}
 
   SubIt2& operator=(const SubIt2<T>& o){


### PR DESCRIPTION
Github has introduced macos-15 and macos-15-intel runners, and is deprecating macos-13. I've had some trouble with Brille tests on Euphonic while trying the new runners, so thought I'd try enabling them upstream...

This produced some compiler errors

```
/Users/runner/work/brille/brille/src/subscript.hpp:138:85: error: no member named 'first' in 'SubIt<T>'; did you mean '_first'?
  138 |   : _shape(o->_shape), _inpt(o->_inpt), _sub(o->_sub), _fixed(o->_fixed), _first(o->first)
      |                                                                                     ^~~~~
      |                                                                                     _first
/Users/runner/work/brille/brille/src/subscript.hpp:82:10: note: '_first' declared here
   82 |   size_t _first;
      |          ^
/Users/runner/work/brille/brille/src/subscript.hpp:251:85: error: no member named 'first' in 'SubIt2<T>'; did you mean '_first'?
  251 |   : _shape(o->_shape), _inpt(o->_inpt), _sub(o->_sub), _fixed(o->_fixed), _first(o->first)
      |                                                                                     ^~~~~
      |                                                                                     _first
```

I'm not very familiar with the kinds of `_name_mangling` that can happen around C++ header files, so maybe there was a good reason for this inconsistency? But by following the suggested change `o->first` -> `o->_first` the tests now seem to pass on all build platforms.

A concerning thing is that the macos-14 and macos-15 platforms seem to be _really slow_ builds (>20 min and >30 min respectively) compared with macos-13 and macos-15-intel.

Github will terminate macos-13 in December so it does need to update at some point.